### PR TITLE
chore: declare Python 3.14 support

### DIFF
--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10', '3.11' ,'3.12', '3.13' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13', '3.14' ]
         os: [ ubuntu-latest, windows-latest ] # , ubuntu-latest, macos-latest
 
     steps:
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pdm install --no-lock -G testing
+          pdm install --no-lock -G dev
 
       - name: Run Regular Tests
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.1] - 2026-05-06
+
+- Packaging: Declare Python 3.14 support and publish package metadata classifiers for Python 3.9 through 3.14.
+- CI: Add Python 3.14 to the test matrix.
+
 ## [0.4.0] - 2025-09-15
 
 - Behavior: Always replace newline characters in input to prevent FastText errors. This adjustment is logged at DEBUG level only.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **`fast-langdetect`** is an ultra-fast and highly accurate language detection library based on FastText, a library developed by Facebook. Its incredible speed and accuracy make it 80x faster than conventional methods and deliver up to 95% accuracy.
 
-- Supported Python `3.9` to `3.13`.
+- Supported Python `3.9` to `3.14`.
 - Works offline with the lite model.
 - No `numpy` required (thanks to @dalf).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fast-langdetect"
-version = "1.0.0"
+version = "1.0.1"
 description = "Quickly detect text language and segment language"
 authors = [
     { name = "sudoskys", email = "coldlando@hotmail.com" },
@@ -13,6 +13,14 @@ dependencies = [
 requires-python = ">=3.9"
 readme = "README.md"
 license = { text = "MIT" }
+classifiers = [
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+]
 
 [build-system]
 requires = ["pdm-backend"]


### PR DESCRIPTION
## Summary
- Bump the package version to 1.0.1 for a Python 3.14 support release.
- Add Python 3.14 to package classifiers and the CI matrix.
- Update the README and changelog to document Python 3.14 support.
- Fix the CI dependency group from the non-existent `testing` group to the existing `dev` group.

## Verification
- `FTLANG_CACHE=<isolated-cache-dir> uv run pytest -q tests/test_detect.py tests/test_real_detection.py` -> `22 passed, 1 warning`
- `pdm lock --check` -> passed
- `pdm build` -> built the sdist and wheel successfully
- Wheel metadata check confirmed `Version: 1.0.1` and `Classifier: Programming Language :: Python :: 3.14`

## Compatibility
- Public packaging metadata change only.
- No runtime API, model behavior, or dependency minimum changed.
- Release version is bumped to 1.0.1 so consumers can pick up the new Python support metadata explicitly.

Closes #28