### PR TITLE
fix: make model cache downloads atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.2] - 2026-05-06
+
+- Reliability: Make full-model cache downloads single-writer, checksum-verified, and atomically published to prevent corrupted shared cache files during concurrent first use.
+
 ## [1.0.1] - 2026-05-06
 
 - Packaging: Declare Python 3.14 support and publish package metadata classifiers for Python 3.9 through 3.14.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fast-langdetect"
-version = "1.0.1"
+version = "1.0.2"
 description = "Quickly detect text language and segment language"
 authors = [
     { name = "sudoskys", email = "coldlando@hotmail.com" },

--- a/src/fast_langdetect/infer.py
+++ b/src/fast_langdetect/infer.py
@@ -3,12 +3,15 @@
 FastText based language detection module.
 """
 
+import hashlib
 import logging
 import os
 import platform
 import re
 import shutil
 import tempfile
+import time
+import uuid
 from pathlib import Path
 from typing import Dict, List, Optional, Union, Any, Literal
 
@@ -24,7 +27,10 @@ FASTTEXT_LARGE_MODEL_URL = (
     "https://dl.fbaipublicfiles.com/fasttext/supervised-models/lid.176.bin"
 )
 FASTTEXT_LARGE_MODEL_NAME = "lid.176.bin"
+FASTTEXT_LARGE_MODEL_MD5 = "01810bc59c6a3d2b79c79e6336612f65"
 _LOCAL_SMALL_MODEL_PATH = Path(__file__).parent / "resources" / "lid.176.ftz"
+_MODEL_DOWNLOAD_LOCK_TIMEOUT_SECONDS = 600.0
+_MODEL_DOWNLOAD_LOCK_POLL_SECONDS = 0.1
 
 
 class FastLangdetectError(Exception):
@@ -41,51 +47,141 @@ class ModelDownloader:
     """Model download handler."""
 
     @staticmethod
-    def download(url: str, save_path: Path, proxy: Optional[str] = None) -> None:
+    def _file_md5(path: Path) -> str:
+        hasher = hashlib.md5()
+        with path.open("rb") as file:
+            for chunk in iter(lambda: file.read(1024 * 1024), b""):
+                hasher.update(chunk)
+        return hasher.hexdigest()
+
+    @classmethod
+    def _is_valid_model(cls, path: Path, expected_md5: Optional[str]) -> bool:
+        if not path.exists():
+            return False
+        if expected_md5 is None:
+            return True
+        try:
+            return cls._file_md5(path) == expected_md5
+        except OSError:
+            return False
+
+    @staticmethod
+    def _acquire_lock(
+        lock_path: Path,
+        timeout: float = _MODEL_DOWNLOAD_LOCK_TIMEOUT_SECONDS,
+    ) -> None:
+        deadline = time.monotonic() + timeout
+        while True:
+            try:
+                lock_path.mkdir()
+                return
+            except FileExistsError:
+                if time.monotonic() >= deadline:
+                    raise FastLangdetectError(
+                        f"fast-langdetect: Timed out waiting for model cache lock: {lock_path}"
+                    )
+                time.sleep(_MODEL_DOWNLOAD_LOCK_POLL_SECONDS)
+
+    @staticmethod
+    def _release_lock(lock_path: Path) -> None:
+        try:
+            lock_path.rmdir()
+        except FileNotFoundError:
+            return
+        except OSError as e:
+            logger.warning(
+                f"fast-langdetect: Failed to release model cache lock {lock_path}: {e}"
+            )
+
+    @staticmethod
+    def _ensure_parent_dir(save_path: Path) -> None:
+        parent_dir = save_path.parent
+        default_cache_dir = Path(CACHE_DIRECTORY)
+        if parent_dir.exists():
+            return
+
+        # Only auto-create when using the library's default cache dir.
+        if parent_dir == default_cache_dir:
+            try:
+                parent_dir.mkdir(parents=True, exist_ok=True)
+            except Exception as e:
+                raise FastLangdetectError(
+                    f"fast-langdetect: Cannot create cache directory {parent_dir}: {e}"
+                ) from e
+            return
+
+        # For user-specified cache_dir, do not fallback; raise.
+        raise FileNotFoundError(f"fast-langdetect: Cache directory not found: {parent_dir}")
+
+    @classmethod
+    def download(
+        cls,
+        url: str,
+        save_path: Path,
+        proxy: Optional[str] = None,
+        expected_md5: Optional[str] = None,
+        lock_timeout: float = _MODEL_DOWNLOAD_LOCK_TIMEOUT_SECONDS,
+    ) -> None:
         """
         Download model file if not exists.
 
         :param url: URL to download from
         :param save_path: Path to save the model
         :param proxy: Optional proxy URL
+        :param expected_md5: Optional expected MD5 checksum for the completed file
+        :param lock_timeout: Seconds to wait for another process downloading this model
 
         :raises:
             FastLangdetectError: If download fails
             FileNotFoundError: If a user-provided cache directory does not exist
         """
-        if save_path.exists():
+        if cls._is_valid_model(save_path, expected_md5):
             logger.info(f"fast-langdetect: Model exists at {save_path}")
             return
 
-        logger.info(f"fast-langdetect: Downloading model from {url}")
-        # Ensure target directory handling is consistent across OSes
-        parent_dir = save_path.parent
-        default_cache_dir = Path(CACHE_DIRECTORY)
-        if not parent_dir.exists():
-            # Only auto-create when using the library's default cache dir
-            if parent_dir == default_cache_dir:
-                try:
-                    parent_dir.mkdir(parents=True, exist_ok=True)
-                except Exception as e:
-                    raise FastLangdetectError(
-                        f"fast-langdetect: Cannot create cache directory {parent_dir}: {e}"
-                    ) from e
-            else:
-                # For user-specified cache_dir, do not fallback; raise
-                raise FileNotFoundError(f"fast-langdetect: Cache directory not found: {parent_dir}")
+        cls._ensure_parent_dir(save_path)
+        lock_path = save_path.with_name(f"{save_path.name}.lock")
+        tmp_path = save_path.with_name(
+            f"{save_path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp"
+        )
+
+        cls._acquire_lock(lock_path, timeout=lock_timeout)
         try:
+            if cls._is_valid_model(save_path, expected_md5):
+                logger.info(f"fast-langdetect: Model exists at {save_path}")
+                return
+
+            if save_path.exists():
+                logger.warning(f"fast-langdetect: Removing invalid cached model at {save_path}")
+                save_path.unlink()
+
+            logger.info(f"fast-langdetect: Downloading model from {url}")
             download(
                 url=url,
-                folder=str(save_path.parent),
-                filename=save_path.name,
+                folder=str(tmp_path.parent),
+                filename=tmp_path.name,
                 proxy=proxy,
                 retry_max=2,
                 sleep_max=5,
                 timeout=7,
             )
+            if not cls._is_valid_model(tmp_path, expected_md5):
+                raise FastLangdetectError(
+                    f"fast-langdetect: Downloaded model failed integrity check: {tmp_path}"
+                )
+            os.replace(tmp_path, save_path)
         except Exception as e:
             # Download failures are library-specific
             raise FastLangdetectError(f"fast-langdetect: Download failed: {e}") from e
+        finally:
+            if tmp_path.exists():
+                try:
+                    tmp_path.unlink()
+                except OSError as e:
+                    logger.warning(
+                        f"fast-langdetect: Failed to delete temporary model file {tmp_path}: {e}"
+                    )
+            cls._release_lock(lock_path)
 
 
 class ModelLoader:
@@ -106,8 +202,13 @@ class ModelLoader:
 
     def load_with_download(self, model_path: Path, proxy: Optional[str] = None) -> Any:
         """Internal method to load model with download if needed."""
-        if not model_path.exists():
-            self._downloader.download(FASTTEXT_LARGE_MODEL_URL, model_path, proxy)
+        if not self._downloader._is_valid_model(model_path, FASTTEXT_LARGE_MODEL_MD5):
+            self._downloader.download(
+                FASTTEXT_LARGE_MODEL_URL,
+                model_path,
+                proxy,
+                expected_md5=FASTTEXT_LARGE_MODEL_MD5,
+            )
         return self.load_local(model_path)
 
     def _load_windows_compatible(self, model_path: Path) -> Any:
@@ -212,7 +313,7 @@ class LangDetectConfig:
 
 class LangDetector:
     """Language detector using FastText models."""
-    VERIFY_FASTTEXT_LARGE_MODEL = "01810bc59c6a3d2b79c79e6336612f65"
+    VERIFY_FASTTEXT_LARGE_MODEL = FASTTEXT_LARGE_MODEL_MD5
 
     def __init__(self, config: Optional[LangDetectConfig] = None):
         """

--- a/tests/test_model_cache.py
+++ b/tests/test_model_cache.py
@@ -1,0 +1,120 @@
+import hashlib
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from fast_langdetect.infer import FastLangdetectError, ModelDownloader, ModelLoader
+
+
+def _md5(data: bytes) -> str:
+    return hashlib.md5(data).hexdigest()
+
+
+def test_downloader_replaces_invalid_cached_model(monkeypatch, tmp_path):
+    model_data = b"valid model"
+    expected_md5 = _md5(model_data)
+    target = tmp_path / "lid.176.bin"
+    target.write_bytes(b"corrupt model")
+
+    def fake_download(*, folder, filename, **kwargs):
+        assert "md5" not in kwargs
+        Path(folder, filename).write_bytes(model_data)
+
+    monkeypatch.setattr("fast_langdetect.infer.download", fake_download)
+
+    ModelDownloader.download(
+        "https://example.invalid/model.bin",
+        target,
+        expected_md5=expected_md5,
+    )
+
+    assert target.read_bytes() == model_data
+    assert not list(tmp_path.glob("*.tmp"))
+    assert not (tmp_path / "lid.176.bin.lock").exists()
+
+
+def test_downloader_does_not_publish_failed_integrity_download(monkeypatch, tmp_path):
+    target = tmp_path / "lid.176.bin"
+    expected_md5 = _md5(b"valid model")
+
+    def fake_download(*, folder, filename, **kwargs):
+        Path(folder, filename).write_bytes(b"wrong model")
+
+    monkeypatch.setattr("fast_langdetect.infer.download", fake_download)
+
+    with pytest.raises(FastLangdetectError, match="integrity check"):
+        ModelDownloader.download(
+            "https://example.invalid/model.bin",
+            target,
+            expected_md5=expected_md5,
+        )
+
+    assert not target.exists()
+    assert not list(tmp_path.glob("*.tmp"))
+    assert not (tmp_path / "lid.176.bin.lock").exists()
+
+
+def test_downloader_times_out_when_cache_lock_is_held(monkeypatch, tmp_path):
+    target = tmp_path / "lid.176.bin"
+    (tmp_path / "lid.176.bin.lock").mkdir()
+    monkeypatch.setattr("fast_langdetect.infer._MODEL_DOWNLOAD_LOCK_POLL_SECONDS", 0)
+
+    with pytest.raises(FastLangdetectError, match="model cache lock"):
+        ModelDownloader.download(
+            "https://example.invalid/model.bin",
+            target,
+            expected_md5=_md5(b"valid model"),
+            lock_timeout=0,
+        )
+
+
+def test_loader_downloads_only_once_for_concurrent_callers(monkeypatch, tmp_path):
+    model_data = b"valid model"
+    expected_md5 = _md5(model_data)
+    target = tmp_path / "lid.176.bin"
+    download_calls = []
+    load_calls = []
+    release_download = threading.Event()
+
+    monkeypatch.setattr("fast_langdetect.infer.FASTTEXT_LARGE_MODEL_MD5", expected_md5)
+
+    def fake_download(*, folder, filename, **kwargs):
+        download_calls.append(filename)
+        Path(folder, filename).write_bytes(model_data)
+        release_download.wait(timeout=2)
+
+    def fake_load_local(self, model_path):
+        load_calls.append(model_path)
+        return object()
+
+    monkeypatch.setattr("fast_langdetect.infer.download", fake_download)
+    monkeypatch.setattr(ModelLoader, "load_local", fake_load_local)
+
+    loaders = [ModelLoader(), ModelLoader()]
+    errors = []
+
+    def load_model(loader):
+        try:
+            loader.load_with_download(target)
+        except Exception as exc:
+            errors.append(exc)
+
+    first = threading.Thread(target=load_model, args=(loaders[0],))
+    second = threading.Thread(target=load_model, args=(loaders[1],))
+
+    first.start()
+    while not download_calls:
+        time.sleep(0.01)
+    second.start()
+    release_download.set()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert errors == []
+    assert len(download_calls) == 1
+    assert len(load_calls) == 2
+    assert target.read_bytes() == model_data


### PR DESCRIPTION
## Summary
- Make full-model downloads publish through a checksum-verified temporary file and atomic replacement.
- Add a single-writer cache lock so concurrent first use does not corrupt the shared model file.
- Revalidate existing cached full models and replace invalid cache entries instead of trusting `exists()`.
- Bump the package version to 1.0.2 and add regression coverage for corrupted cache, failed integrity, lock timeout, and concurrent callers.

## Preflight
- Symptom: concurrent first-time full-model downloads can corrupt the shared cache file, after which existing-file checks reuse the corrupt model.
- Core concepts: `large_model_cache`, `verified_model_file`, `download_lock`.
- Authority points: `ModelDownloader.download` owns downloaded model writes; `ModelLoader.load_with_download` owns download-before-load; `LangDetector._get_model` chooses the full-model cache path.
- Call chain: public `detect()` -> `LangDetector.detect()` -> `_get_model(low_memory=False)` -> `ModelLoader.load_with_download()` -> `ModelDownloader.download()`.
- Change locus: cache-write layer, same layer as the cache authority.
- Root-cause hypothesis: corruption happens because multiple processes write the same target path without single-writer coordination or checksum-gated publication.
- Falsification: the existing wrapper only checked whether the final file existed before reuse; no lock, temporary publication path, or checksum validation guarded final cache visibility.

## Verification
- `uv run pytest -q tests/test_model_cache.py` -> `4 passed`
- `FTLANG_CACHE=<isolated-cache-dir> uv run pytest -q tests` -> `26 passed, 1 skipped, 1 warning`
- `pdm lock --check` -> passed
- `pdm build` -> built the sdist and wheel successfully
- Wheel metadata check confirmed `Version: 1.0.2`

## Compatibility
- No public `detect()` API change.
- No new runtime dependency.
- Existing invalid full-model cache files are replaced when the checksum does not match the expected model checksum.
- `model="auto"` still only falls back to lite on `MemoryError`; cache/download/integrity errors still surface as errors.